### PR TITLE
Jekyll 3 port

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'github-pages', '> 43'
+gem 'github-pages', '>= 89'
 gem 'git'
 # gem 'jekyll-paginate'
 group :jekyll_plugins do

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem 'github-pages', '>= 89'
 gem 'git'
+gem 'rouge'
 # gem 'jekyll-paginate'
 group :jekyll_plugins do
   gem 'octopress-hooks', git: 'https://github.com/octopress/hooks.git'

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,9 @@
 source 'https://rubygems.org'
 
-gem 'github-pages', '= 43'
+gem 'github-pages', '> 43'
 gem 'git'
-gem 'jekyll-paginate'
+# gem 'jekyll-paginate'
+group :jekyll_plugins do
+  gem 'octopress-hooks', git: 'https://github.com/octopress/hooks.git'
+  gem 'octopress-paginate'
+end

--- a/_config.yml
+++ b/_config.yml
@@ -34,14 +34,12 @@ pagination:
 
 excerpt_separator: "<!--more-->"
 
-collections:
-  math_resources:
-    output: true
-    permalink: /resources/m/:path/
-  cs_resources:
-    output: true
-    permalink: /resources/cs/:path/
-
+exclude:
+  - Gemfile
+  - Gemfile.lock
+  - LICENSE
+  - README.md
+  - Rakefile
 
 # Autores
 authors:

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,6 @@
-﻿# Github defaults:
-safe: true
+
+# Github defaults
+# safe: true
 lsi: false
 
 # Settings
@@ -16,13 +17,19 @@ kramdown:
 # Dependencies
 gems:
   - jemoji
-  - jekyll-paginate
+  - octopress-paginate
   - jekyll-gist
 #  - jekyll-mentions
 
-permalink: /:year/:month/:day/:title
-paginate: 5
-paginate_path: "/page/:num/"
+permalink: /:year/:month/:day/:title/
+# paginate: 5
+# paginate_path: "/page/:num/"
+# Configure octopress-paginate:
+pagination:
+  per_page: 5
+  limit: false
+  permalink: /page/:num/
+  title_suffix: ""
 
 excerpt_separator: "<!--more-->"
 

--- a/_config.yml
+++ b/_config.yml
@@ -13,6 +13,7 @@ url: http://libreim.github.io/blog
 markdown: kramdown
 kramdown:
   parse_span_html: false
+highlighter: rouge
 
 # Dependencies
 gems:

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,7 +5,7 @@
       <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/pure/0.6.0/grids-responsive-min.css" />
       <!--link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/pure/0.6.0/menus-min.css" /-->
       <link rel="stylesheet" type="text/css" href="{{ site.assets_path }}/css/default.css" />
-      <link rel="stylesheet" type="text/css" href="{{ site.assets_path }}/css/github.min.css" />
+      <link rel="stylesheet" type="text/css" href="{{ site.assets_path }}/css/pygments-friendly.css" />
       <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ site.assets_path }}/feed.xml" />
 
       <!-- Favicon -->
@@ -19,7 +19,6 @@
       <meta charset="utf-8">
       <script src="//ajax.googleapis.com/ajax/libs/webfont/1.4.7/webfont.js"></script>
       <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
-      <script type="text/javascript" src="{{ site.assets_path }}/js/highlight.pack.js"></script>
 
       <script type="text/javascript">
          WebFont.load({
@@ -28,7 +27,6 @@
             }
          });
       </script>
-      <script>hljs.initHighlightingOnLoad();</script>
       <script type="text/javascript">
             MathJax.Hub.Config({
                tex2jax: {

--- a/index.html
+++ b/index.html
@@ -1,9 +1,8 @@
 ---
 title: Blog
 layout: default
-
+paginate: true
 ---
-<style type="text/css">header .l-blog { color: #c0c0c0; }</style>
 
 {% for post in paginator.posts %}
   {% assign content = post.content %}


### PR DESCRIPTION
Cambios:

* Versión mínima de la gema `github-pages`: 89 (conviene usar `bundle update` para actualizar todas las dependencias).
* El código se colorea ahora en el servidor mediante [jneen/rouge](/jneen/rouge). Eliminado el script de highlight.js.
* La paginación funciona ahora con [octopress/paginate](/octopress/paginate), que da un poco más de juego que jekyll-paginate (además se integra con [octopress/multilingual](/octopress/multilingual), mirando un poco a #28).
* Se excluyen algunos archivos (Readme, License y demás) del blog generado por Jekyll.