### PR TITLE
Eliminar whitespace creado por jekyll

### DIFF
--- a/_includes/banner
+++ b/_includes/banner
@@ -1,29 +1,29 @@
-<{% if include.link %}a href="{{ include.link }}"{% else %}div{% endif %}
-    class="introduction {{ include.side }} {{ include.classes }}">
+<{%- if include.link -%}a href="{{- include.link -}}"{%- else -%}div{%- endif -%}
+    class="introduction {{- include.side -}} {{- include.classes -}}">
   <div class="pure-g">
     <div class="pure-u-1-24 pure-u-md-1-24 pure-u-lg-1-5"></div>
     <div class="pure-u-22-24 pure-u-md-22-24 pure-u-lg-3-5">
 
       <div class="pure-g">
-        {% if include.side == "right" %}
+        {%- if include.side == "right" -%}
         <div class="pure-u-1-6 pure-u-lg-1-2"></div>
-        {% endif %}
+        {%- endif -%}
         
         <div class="pure-u-5-6 pure-u-lg-1-2">
-          <h1>{{ include.title }}</h1>
-          <p>{{ include.description | markdownify }}</p>
+          <h1>{{- include.title -}}</h1>
+          <p>{{- include.description | markdownify -}}</p>
         </div>
         
-        {% if include.side == "left" %}
+        {%- if include.side == "left" -%}
         <div class="pure-u-1-6 pure-u-lg-1-2"></div>
-        {% endif %}
+        {%- endif -%}
       </div>
 
       <div class="pure-u-1-24 pure-u-md-1-24 pure-u-lg-1-5"></div>
     </div>
   </div>
-{% if include.link %}
+{%- if include.link -%}
 </a>
-{% else %}
+{%- else -%}
 </div>
-{% endif %}
+{%- endif -%}

--- a/_includes/breadcrumbs.html
+++ b/_includes/breadcrumbs.html
@@ -1,12 +1,12 @@
 <div class="breadcrumbs category">
-  <a href="{{ site.baseurl }}/recursos">recursos</a><span class="separator"></span>
-  {% assign tag_path = include.tag | split: "/" %}
-  {% assign prev_path = "" %}
+  <a href="{{- site.baseurl -}}/recursos">recursos</a><span class="separator"></span>
+  {%- assign tag_path = include.tag | split: "/" -%}
+  {%- assign prev_path = "" -%}
   
-  {% for prev in tag_path %}
-  {% if forloop.last == false %}
-  {% assign prev_path = prev_path | append: "/" | append: prev %}
-  <a href="{{ site.baseurl }}{{ site.tag_dir }}{{ prev_path }}">{{ prev }}</a><span class="separator"></span>
-  {% endif %}
-  {% endfor %}
+  {%- for prev in tag_path -%}
+  {%- if forloop.last == false -%}
+  {%- assign prev_path = prev_path | append: "/" | append: prev -%}
+  <a href="{{- site.baseurl -}}{{- site.tag_dir -}}{{- prev_path -}}">{{- prev -}}</a><span class="separator"></span>
+  {%- endif -%}
+  {%- endfor -%}
 </div>

--- a/_includes/figure
+++ b/_includes/figure
@@ -1,6 +1,6 @@
-<figure class="fig {{ include.size }}">
-  <a href="{{ site.assets_path }}/images/blog/{{ include.path }}" title="Ver imagen completa">
-    <img src="{{ site.assets_path }}/images/blog/{{ include.path }}" />
+<figure class="fig {{- include.size -}}">
+  <a href="{{- site.assets_path -}}/images/blog/{{- include.path -}}" title="Ver imagen completa">
+    <img src="{{- site.assets_path -}}/images/blog/{{- include.path -}}" />
   </a>
-  {{ include.caption }}
+  {{- include.caption -}}
 </figure>

--- a/_includes/list_post.html
+++ b/_includes/list_post.html
@@ -1,20 +1,20 @@
 <p class="post-list">
-  <a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a>
-  {% assign authorCount = post.authors | size %}
-  {% if authorCount > 0 %}
+  <a href="{{- site.baseurl -}}{{- post.url -}}">{{- post.title -}}</a>
+  {%- assign authorCount = post.authors | size -%}
+  {%- if authorCount > 0 -%}
     <span class="author">por
-      {% for author in post.authors %}
-        {% if forloop.first %}
-          {% assign authdata = site.authors[author] %}
-          <a href="http://github.com/{{ authdata.github }}">{{ authdata.name }}</a>
-        {% elsif forloop.last %}
-          {% assign authdata = site.authors[author] %}
-          y <a href="http://github.com/{{ authdata.github }}">{{ authdata.name }}</a>
-        {% else %}
-          {% assign authdata = site.authors[author] %}
-          , <a href="http://github.com/{{ authdata.github }}">{{ authdata.name }}</a>
-        {% endif %}
-      {% endfor %}
+      {%- for author in post.authors -%}
+        {%- if forloop.first -%}
+          {%- assign authdata = site.authors[author] -%}
+          <a href="http://github.com/{{- authdata.github -}}">{{- authdata.name -}}</a>
+        {%- elsif forloop.last -%}
+          {%- assign authdata = site.authors[author] -%}
+          y <a href="http://github.com/{{- authdata.github -}}">{{- authdata.name -}}</a>
+        {%- else -%}
+          {%- assign authdata = site.authors[author] -%}
+          , <a href="http://github.com/{{- authdata.github -}}">{{- authdata.name -}}</a>
+        {%- endif -%}
+      {%- endfor -%}
     </span>
-  {% endif %}
+  {%- endif -%}
 </p>

--- a/_includes/pagination.html
+++ b/_includes/pagination.html
@@ -15,7 +15,7 @@
         {%- endif -%}
       </div>
       <div class="paginator pure-u-1-3 pure-u-md-1-3 pure-u-lg-1-5">
-        <span class="page-number">Página {{-paginator.page-}} de {{-paginator.total_pages-}}</span>
+        <span class="page-number">Página {{paginator.page}} de {{paginator.total_pages}}</span>
         {%- if include.archive -%}
         <span class="archive-link"><a href="{{- site.baseurl -}}/{{- include.site -}}/archive">Todos los posts</a></span>
         {%- endif -%}

--- a/_includes/pagination.html
+++ b/_includes/pagination.html
@@ -4,28 +4,28 @@
   <div class="pure-u-22-24 pure-u-md-22-24 pure-u-lg-3-5 pure-u-xl-2-5">
     <div class="pure-g">-->
       <div class="paginator pure-u-1-3 pure-u-md-1-3 pure-u-lg-2-5">
-        {% if paginator.previous_page %}
-          {% if paginator.previous_page == 1 %}
-            <a href="{{ site.baseurl }}/{{ include.site }}" class="arrow">&larr;</a>
-          {% else %}
-            <a href="{{ site.baseurl }}{{ paginator.previous_page_path }}" class="next arrow" >&larr;</a>
-          {% endif %}
-        {% else %}
+        {%- if paginator.previous_page -%}
+          {%- if paginator.previous_page == 1 -%}
+            <a href="{{- site.baseurl -}}/{{- include.site -}}" class="arrow">&larr;</a>
+          {%- else -%}
+            <a href="{{- site.baseurl -}}{{- paginator.previous_page_path -}}" class="next arrow" >&larr;</a>
+          {%- endif -%}
+        {%- else -%}
           <span class="disabled-link arrow">&larr;</span>
-        {% endif %}
+        {%- endif -%}
       </div>
       <div class="paginator pure-u-1-3 pure-u-md-1-3 pure-u-lg-1-5">
-        <span class="page-number">Página {{paginator.page}} de {{paginator.total_pages}}</span>
-        {% if include.archive %}
-        <span class="archive-link"><a href="{{ site.baseurl }}/{{ include.site }}/archive">Todos los posts</a></span>
-        {% endif %}
+        <span class="page-number">Página {{-paginator.page-}} de {{-paginator.total_pages-}}</span>
+        {%- if include.archive -%}
+        <span class="archive-link"><a href="{{- site.baseurl -}}/{{- include.site -}}/archive">Todos los posts</a></span>
+        {%- endif -%}
       </div>
       <div class="paginator pure-u-1-3 pure-u-md-1-3 pure-u-lg-2-5">
-        {% if paginator.next_page <= paginator.total_pages %}
-          <a href="{{ site.baseurl }}{{ paginator.next_page_path }}" class="next arrow">&rarr;</a>
-        {% else %}
+        {%- if paginator.next_page <= paginator.total_pages -%}
+          <a href="{{- site.baseurl -}}{{- paginator.next_page_path -}}" class="next arrow">&rarr;</a>
+        {%- else -%}
           <span class="disabled-link arrow">&rarr;</span>
-        {% endif %}
+        {%- endif -%}
       </div>
     <!--</div>
   </div>

--- a/_includes/tag_list.html
+++ b/_includes/tag_list.html
@@ -1,44 +1,44 @@
 <ul class="tag-tree level-1">
-  {% if include.prefix %}
-  {% assign tag_prefix = include.prefix | append: "/" %}
-  {% else %}
-  {% assign tag_prefix = "" %}
-  {% endif %}
-  {% assign children_count = 0 %}
+  {%- if include.prefix -%}
+  {%- assign tag_prefix = include.prefix | append: "/" -%}
+  {%- else -%}
+  {%- assign tag_prefix = "" -%}
+  {%- endif -%}
+  {%- assign children_count = 0 -%}
   
-  {% for tag in site.tags %}
-  {% assign tag_name = tag | first %}
-  {% if tag_name contains tag_prefix %}
-  {% assign tag_remainder = tag_name | remove_first: tag_prefix %}
-  {% if tag_remainder contains "/" %}{% else %}
+  {%- for tag in site.tags -%}
+  {%- assign tag_name = tag | first -%}
+  {%- if tag_name contains tag_prefix -%}
+  {%- assign tag_remainder = tag_name | remove_first: tag_prefix -%}
+  {%- if tag_remainder contains "/" -%}{%- else -%}
   
-  {% assign children_count = children_count | plus: 1 %}
+  {%- assign children_count = children_count | plus: 1 -%}
   <li>
-    <a href="{{ site.baseurl }}{{ site.tag_dir }}/{{ tag_name }}">{{ tag_remainder }}</a>
-    {% assign level = include.level | default: 1 %}
-    {% if level == 2 %}
+    <a href="{{- site.baseurl -}}{{- site.tag_dir -}}/{{- tag_name -}}">{{- tag_remainder -}}</a>
+    {%- assign level = include.level | default: 1 -%}
+    {%- if level == 2 -%}
     <ul class="tag-tree level-2">
-      {% assign tag2_prefix = tag_name | append: "/" %}
+      {%- assign tag2_prefix = tag_name | append: "/" -%}
       
-      {% for tag2 in site.tags %}
-      {% assign tag2_name = tag2 | first %}
-      {% if tag2_name contains tag2_prefix %}
-      {% assign tag2_remainder = tag2_name | remove_first: tag2_prefix %}
-      {% if tag2_remainder contains "/" %}{% else %}
+      {%- for tag2 in site.tags -%}
+      {%- assign tag2_name = tag2 | first -%}
+      {%- if tag2_name contains tag2_prefix -%}
+      {%- assign tag2_remainder = tag2_name | remove_first: tag2_prefix -%}
+      {%- if tag2_remainder contains "/" -%}{%- else -%}
       <li>
-        <a href="{{ site.baseurl }}{{ site.tag_dir }}/{{ tag2_name }}">{{ tag2_remainder }}</a>
+        <a href="{{- site.baseurl -}}{{- site.tag_dir -}}/{{- tag2_name -}}">{{- tag2_remainder -}}</a>
       </li>
-      {% endif %}
-      {% endif %}
-      {% endfor %}
+      {%- endif -%}
+      {%- endif -%}
+      {%- endfor -%}
     </ul>
-    {% endif %}
+    {%- endif -%}
   </li>
-  {% endif %}
-  {% endif %}
-  {% endfor %}
+  {%- endif -%}
+  {%- endif -%}
+  {%- endfor -%}
 
-  {% if children_count == 0 %}
+  {%- if children_count == 0 -%}
   <p class="em no-tags">(No hay etiquetas descendientes)</p>
-  {% endif %}
+  {%- endif -%}
 </ul>

--- a/_layouts/category_index.html
+++ b/_layouts/category_index.html
@@ -4,39 +4,39 @@ breadcrumbs: false
 tag_list: false
 ---
 
-{% for post in site.categories.blog %}
-{% if post.category == page.category %}
+{%- for post in site.categories.blog -%}
+{%- if post.category == page.category -%}
 <article>
   <p class="post-title">
-    <a href='{% if post.link %}{{ post.link }}{% else %}{{ post.url }}{% endif %}' class="title">
-      {% if post.link %}
+    <a href='{%- if post.link -%}{{- post.link -}}{%- else -%}{{- post.url -}}{%- endif -%}' class="title">
+      {%- if post.link -%}
       <i class="icon icon-small icon-link-ext"></i>
-      {% endif %}
-      {{ post.title }}
+      {%- endif -%}
+      {{- post.title -}}
     </a>
-    {{ post.content }}
+    {{- post.content -}}
   </p>
   <span class="post-data">
-    {% for author in post.authors %}
-    {% if forloop.first %} {% elsif forloop.last %} y {% else %}, {% endif %}
-    <span class="author">{{ author }}</span>
-    {% endfor %}
+    {%- for author in post.authors -%}
+    {%- if forloop.first -%} {%- elsif forloop.last -%} y {%- else -%}, {%- endif -%}
+    <span class="author">{{- author -}}</span>
+    {%- endfor -%}
 
-    {% if post.license %}
+    {%- if post.license -%}
     <span class="license">
-      {{ post.license }}
+      {{- post.license -}}
     </span>
-    {% endif %}
+    {%- endif -%}
     
-    <a class="date" href='{{ site.baseurl }}{{ post.url }}'><time datetime='{{ post.date | date: "%Y-%m-%d" }}'>Añadido el {{ post.date | date: "%d/%m/%Y" }}</time></a>
+    <a class="date" href='{{- site.baseurl -}}{{- post.url -}}'><time datetime='{{- post.date | date: "%Y-%m-%d" -}}'>Añadido el {{- post.date | date: "%d/%m/%Y" -}}</time></a>
   
     <p class="tag-list">
       <i class="icon icon-tags"></i>
-      {% for tag in post.tags %}
-      <a class="tag-list-link" href="{{ site.baseurl }}{{ site.tag_dir }}/{{ tag }}">{{ tag }}</a>{% if forloop.last == false %}<i class="separator"></i>{% endif %}
-      {% endfor %}
+      {%- for tag in post.tags -%}
+      <a class="tag-list-link" href="{{- site.baseurl -}}{{- site.tag_dir -}}/{{- tag -}}">{{- tag -}}</a>{%- if forloop.last == false -%}<i class="separator"></i>{%- endif -%}
+      {%- endfor -%}
     </p>
   </span>
 </article>
-{% endif %}
-{% endfor %}
+{%- endif -%}
+{%- endfor -%}

--- a/_layouts/collection_index.html
+++ b/_layouts/collection_index.html
@@ -2,6 +2,6 @@
 layout: content
 ---
 
-{% for element in page.col %}
-<p><a href="{{ site.baseurl }}{{ element.url }}">{{ element.title }}</a>
-{% endfor %}
+{%- for element in page.col -%}
+<p><a href="{{- site.baseurl -}}{{- element.url -}}">{{- element.title -}}</a>
+{%- endfor -%}

--- a/_layouts/content-outer.html
+++ b/_layouts/content-outer.html
@@ -5,8 +5,8 @@ layout: default
 <div class="pure-g">
   <div class="pure-u-1-24 pure-u-md-1-24 pure-u-lg-1-5"></div>
   <div class="pure-u-22-24 pure-u-md-22-24 pure-u-lg-3-5 pure-u-xl-3-5">
-    <article class="container" lang="{% if page.lang %}{{ post.lang }}{% else %}es{% endif %}">
-      {{ content }}
+    <article class="container" lang="{%- if page.lang -%}{{- post.lang -}}{%- else -%}es{%- endif -%}">
+      {{- content -}}
     </article>
   </div>
   <div class="pure-u-1-24 pure-u-md-1-24 pure-u-lg-1-5 pure-u-xl-1-5"></div>

--- a/_layouts/content.html
+++ b/_layouts/content.html
@@ -3,60 +3,60 @@ layout: content-outer
 ---
 
 
-{% if page.category %}
+{%- if page.category -%}
 <div class="category">
-  {{ page.category }}
+  {{- page.category -}}
 </div>
-{% endif %}
+{%- endif -%}
 
-{% if page.breadcrumbs %}
-{% include breadcrumbs.html tag=page.tag %}
-{% endif %}
+{%- if page.breadcrumbs -%}
+{%- include breadcrumbs.html tag=page.tag -%}
+{%- endif -%}
 
-{% if page.title %}
+{%- if page.title -%}
 <h1>
-  {% if page.link %}
+  {%- if page.link -%}
   <span>
-    <a href="{{ site.baseurl }}{{ page.url }}">{{ page.title }}</a>
+    <a href="{{- site.baseurl -}}{{- page.url -}}">{{ page.title }}</a>
     
-    <a class="post-link" href="{{ page.link }}">
+    <a class="post-link" href="{{- page.link -}}">
       <i class="icon icon-link-ext"></i>
-      {{ page.link | split: "://" | last | split: "/" | first }}
+      {{- page.link | split: "://" | last | split: "/" | first -}}
     </a>
   </span>
-  {% else %}
-  <a href="{{ site.baseurl }}{{ page.url }}">
-    {{ page.title }}
+  {%- else -%}
+  <a href="{{- site.baseurl -}}{{- page.url -}}">
+    {{- page.title -}}
   </a>
-  {% endif %}
+  {%- endif -%}
 </h1>
-{% endif %}
+{%- endif -%}
 
-{% if page.tag_list or page.side %}
+{%- if page.tag_list or page.side -%}
 
 <div class="pure-g">
   <div class="pure-u-1 pure-u-md-2-3 pure-u-lg-2-3">
-    {{ content }}        
+    {{- content -}}        
   </div>
   <div class="pure-u-1 pure-u-md-1-24 pure-u-lg-1-24"></div>
   <div class="pure-u-1 pure-u-md-7-24 pure-u-lg-7-24">
-    {% if page.tag_list %}
-    <a href="{{ site.baseurl }}/recursos/new" class="pure-button pure-button-primary">
+    {%- if page.tag_list -%}
+    <a href="{{- site.baseurl -}}/recursos/new" class="pure-button pure-button-primary">
       <i class="fa icon icon-plus"></i>
       Añadir un nuevo recurso
     </a>
     
-    <h3>Etiquetas{% if page.tag_prefix %} descendientes{% endif %}</h3>
-    {% if page.tag_prefix %}
-    {% include tag_list.html level=2 prefix=page.tag %}
-    {% else %}
-    {% include tag_list.html level=2 %}
-    {% endif %}
+    <h3>Etiquetas{%- if page.tag_prefix -%} descendientes{%- endif -%}</h3>
+    {%- if page.tag_prefix -%}
+    {%- include tag_list.html level=2 prefix=page.tag -%}
+    {%- else -%}
+    {%- include tag_list.html level=2 -%}
+    {%- endif -%}
 
-    {% endif %}
+    {%- endif -%}
   </div>
 </div>
 
-{% else %}
-{{ content }}
-{% endif %}
+{%- else -%}
+{{- content -}}
+{%- endif -%}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,20 +10,20 @@
 
       <!-- Fonts -->
       <link href="https://fonts.googleapis.com/css?family=Lato:400,300,700,400italic:latin|Source+Code+Pro:400,700:latin" rel="stylesheet">
-      <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/assets/fonts/css/iconim.css" />
+      <link rel="stylesheet" type="text/css" href="{{- site.baseurl -}}/assets/fonts/css/iconim.css" />
 
       <!-- Style -->
-      <link rel="stylesheet" type="text/css" href="{{ site.assets_path }}/css/default.css" />
-      <link rel="stylesheet" type="text/css" href="{{ site.assets_path }}/css/pygments-friendly.css" />
+      <link rel="stylesheet" type="text/css" href="{{- site.assets_path -}}/css/default.css" />
+      <link rel="stylesheet" type="text/css" href="{{- site.assets_path -}}/css/pygments-friendly.css" />
 
       <!-- RSS Feed -->
-      <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ site.baseurl }}/blog/feed.xml" />
+      <link rel="alternate" type="application/rss+xml" title="RSS" href="{{- site.baseurl -}}/blog/feed.xml" />
 
       <!-- Favicon -->
-      <link rel="shortcut icon" type="image/x-icon" href="{{ site.assets_path }}/images/favicon.ico" />
-      <link rel="apple-touch-icon" sizes="160x160" href="{{ site.assets_path }}/images/favicon-160.png">
+      <link rel="shortcut icon" type="image/x-icon" href="{{- site.assets_path -}}/images/favicon.ico" />
+      <link rel="apple-touch-icon" sizes="160x160" href="{{- site.assets_path -}}/images/favicon-160.png">
       <meta name="msapplication-TileColor" content="#FFFFFF">
-      <meta name="msapplication-TileImage" content="{{ site.assets_path }}/images/favicon-160.png">
+      <meta name="msapplication-TileImage" content="{{- site.assets_path -}}/images/favicon-160.png">
       <meta name="theme-color" content="#6789ab">
 
       <!-- Mathjax: load asynchronously -->
@@ -39,11 +39,11 @@
         });
       </script>
       
-      <title>{{ page.title }} - {{ site.title }}</title>
+      <title>{{- page.title -}} - {{- site.title -}}</title>
    </head>
-   <body class="{% for cl in page.bodyclass %}{{ cl }} {% endfor %}">
-      {% include header.html %}
-      {{ content }}
-      {% include footer.html %}
+   <body class="{%- for cl in page.bodyclass -%}{{- cl -}} {%- endfor -%}">
+      {%- include header.html -%}
+      {{- content -}}
+      {%- include footer.html -%}
    </body>
 </html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -39,7 +39,7 @@
         });
       </script>
       
-      <title>{{- page.title -}} - {{- site.title -}}</title>
+      <title>{{- page.title -}} - {{ site.title }}</title>
    </head>
    <body class="{%- for cl in page.bodyclass -%}{{- cl -}} {%- endfor -%}">
       {%- include header.html -%}

--- a/_layouts/post-outer.html
+++ b/_layouts/post-outer.html
@@ -2,57 +2,57 @@
 layout: content
 ---
 
-{% assign post = page %}
+{%- assign post = page -%}
 
 <div class="post-data">
-  {% assign authorCount = post.authors | size %}
-  {% if authorCount > 0 %}
-  {% for author in post.authors %}
-  {% if forloop.first %} {% elsif forloop.last %} y {% else %}, {% endif %}
-  <span class="author">{{ author }}</span>
-  {% endfor %}
-  {% endif %}
+  {%- assign authorCount = post.authors | size -%}
+  {%- if authorCount > 0 -%}
+  {%- for author in post.authors -%}
+  {%- if forloop.first -%} {%- elsif forloop.last -%} y {%- else -%}, {%- endif -%}
+  <span class="author">{{- author -}}</span>
+  {%- endfor -%}
+  {%- endif -%}
 
-  {% if post.license %}
+  {%- if post.license -%}
   <span class="license">
-    {{ post.license }}
+    {{- post.license -}}
   </span>
-  {% endif %}
+  {%- endif -%}
   
-  <a class="date" href="{{ post.url | prepend: site.baseurl }}">
-    {{ post.date | date: "%d-%m-%Y" }}
+  <a class="date" href="{{- post.url | prepend: site.baseurl -}}">
+    {{- post.date | date: "%d-%m-%Y" -}}
   </a>
-  <a class="dsq-comment-count comments" href="{{ post.url | prepend: site.baseurl }}#disqus_thread" data-disqus-identifier="{{ post.id }}">
+  <a class="dsq-comment-count comments" href="{{- post.url | prepend: site.baseurl -}}#disqus_thread" data-disqus-identifier="{{- post.id -}}">
 
   </a>
 </div>
 
 <div class="post-content">
 
-  {{ content }}
+  {{- content -}}
 
-  {% if excerpt %}
-  <p><a href="{{ site.baseurl }}{{ post.url }}">Seguir leyendo...</a></p>
-  {% endif %}
+  {%- if excerpt -%}
+  <p><a href="{{- site.baseurl -}}{{- post.url -}}">Seguir leyendo...</a></p>
+  {%- endif -%}
 
-  {% if post.editors != nil %}
+  {%- if post.editors != nil -%}
   <p class="post-editors">
-    {% assign eds = post.editors | size %}
-    Ha{% if eds > 1 %}n{% endif %} colaborado en este artículo: {{ post.editors | join: ", " }}
+    {%- assign eds = post.editors | size -%}
+    Ha{%- if eds > 1 -%}n{%- endif -%} colaborado en este artículo: {{- post.editors | join: ", " -}}
   </p>
-  {% endif %}
+  {%- endif -%}
 
   <div class="post-data">
     <p class="tag-list">
       <i class="icon icon-tags"></i>
-      {% assign tag_count = 0 %}
-      {% for tag in post.tags %}
-      {% assign tag_count = tag_count | plus: 1 %}
-      <a class="tag-list-link" href="{{ site.baseurl }}{{ site.tag_dir }}/{{ tag }}">{{ tag }}</a>{% if forloop.last == false %}<i class="separator"></i>{% endif %}
-      {% endfor %}
-      {% if tag_count == 0 %}
+      {%- assign tag_count = 0 -%}
+      {%- for tag in post.tags -%}
+      {%- assign tag_count = tag_count | plus: 1 -%}
+      <a class="tag-list-link" href="{{- site.baseurl -}}{{- site.tag_dir -}}/{{- tag -}}">{{- tag -}}</a>{%- if forloop.last == false -%}<i class="separator"></i>{%- endif -%}
+      {%- endfor -%}
+      {%- if tag_count == 0 -%}
       <span class="em">(sin etiquetas)</span>
-      {% endif %}
+      {%- endif -%}
     </p>
   </div>
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -3,8 +3,8 @@ layout: post-outer
 tag_list: true
 ---
 
-{% if page.toc %}
-{{ content | toc }}
-{% else %}
-{{ content }}
-{% endif %}
+{%- if page.toc -%}
+{{- content | toc -}}
+{%- else -%}
+{{- content -}}
+{%- endif -%}

--- a/_layouts/resource.html
+++ b/_layouts/resource.html
@@ -2,5 +2,5 @@
 layout: default
 ---
 
-{% assign post = page %}
-{% include post.ext %}
+{%- assign post = page -%}
+{%- include post.ext -%}

--- a/_layouts/tag_index.html
+++ b/_layouts/tag_index.html
@@ -5,41 +5,41 @@ tag_list: true
 tag_prefix: true
 ---
 
-{% for post in site.posts %}
-{% for tag in post.tags %}
-{% if tag == page.tag %}
+{%- for post in site.posts -%}
+{%- for tag in post.tags -%}
+{%- if tag == page.tag -%}
 <article>
   <p class="post-title">
-    <a href='{% if post.link %}{{ post.link }}{% else %}{{ post.url }}{% endif %}' class="title">
-      {% if post.link %}
+    <a href='{%- if post.link -%}{{- post.link -}}{%- else -%}{{- post.url -}}{%- endif -%}' class="title">
+      {%- if post.link -%}
       <i class="icon icon-small icon-link-ext"></i>
-      {% endif %}
-      {{ post.title }}
+      {%- endif -%}
+      {{- post.title -}}
     </a>
-    {{ post.content | markdownify }}
+    {{- post.content | markdownify -}}
   </p>
   <span class="post-data">
-    {% for author in post.authors %}
-    {% if forloop.first %} {% elsif forloop.last %} y {% else %}, {% endif %}
-    <span class="author">{{ author }}</span>
-    {% endfor %}
+    {%- for author in post.authors -%}
+    {%- if forloop.first -%} {%- elsif forloop.last -%} y {%- else -%}, {%- endif -%}
+    <span class="author">{{- author -}}</span>
+    {%- endfor -%}
 
-    {% if post.license %}
+    {%- if post.license -%}
     <span class="license">
-      {{ post.license }}
+      {{- post.license -}}
     </span>
-    {% endif %}
+    {%- endif -%}
     
-    <a class="date" href='{{ site.baseurl }}{{ post.url }}'><time datetime='{{ post.date | date: "%Y-%m-%d" }}'>Añadido el {{ post.date | date: "%d/%m/%Y" }}</time></a>
+    <a class="date" href='{{- site.baseurl -}}{{- post.url -}}'><time datetime='{{- post.date | date: "%Y-%m-%d" -}}'>Añadido el {{- post.date | date: "%d/%m/%Y" -}}</time></a>
   
     <p class="tag-list">
       <i class="icon icon-tags"></i>
-      {% for tag in post.tags %}
-      <a class="tag-list-link" href="{{ site.baseurl }}{{ site.tag_dir }}/{{ tag }}">{{ tag }}</a>{% if forloop.last == false %}<i class="separator"></i>{% endif %}
-      {% endfor %}
+      {%- for tag in post.tags -%}
+      <a class="tag-list-link" href="{{- site.baseurl -}}{{- site.tag_dir -}}/{{- tag -}}">{{- tag -}}</a>{%- if forloop.last == false -%}<i class="separator"></i>{%- endif -%}
+      {%- endfor -%}
     </p>
   </span>
 </article>
-{% endif %}
-{% endfor %}
-{% endfor %}
+{%- endif -%}
+{%- endfor -%}
+{%- endfor -%}

--- a/_layouts/tag_index.html
+++ b/_layouts/tag_index.html
@@ -30,7 +30,7 @@ tag_prefix: true
     </span>
     {%- endif -%}
     
-    <a class="date" href='{{- site.baseurl -}}{{- post.url -}}'><time datetime='{{- post.date | date: "%Y-%m-%d" -}}'>Añadido el {{- post.date | date: "%d/%m/%Y" -}}</time></a>
+    <a class="date" href='{{- site.baseurl -}}{{- post.url -}}'><time datetime='{{- post.date | date: "%Y-%m-%d" -}}'>Añadido el {{ post.date | date: "%d/%m/%Y" }}</time></a>
   
     <p class="tag-list">
       <i class="icon icon-tags"></i>

--- a/blog/feed.xml
+++ b/blog/feed.xml
@@ -4,18 +4,18 @@ layout: null
 <?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
     <channel>
-        <title>{{ site.name | xml_escape }}</title>
-        <description>{% if site.description %}{{ site.description | xml_escape }}{% endif %}</description>
-        <link>{{ site.url }}</link>
-        <atom:link href="{{ site.url }}/feed.xml" rel="self" type="application/rss+xml" />
-        {% for post in site.categories.blog limit:10 %}
+        <title>{{- site.name | xml_escape -}}</title>
+        <description>{%- if site.description -%}{{- site.description | xml_escape -}}{%- endif -%}</description>
+        <link>{{- site.url -}}</link>
+        <atom:link href="{{- site.url -}}/feed.xml" rel="self" type="application/rss+xml" />
+        {%- for post in site.categories.blog limit:10 -%}
         <item>
-            <title>{{ post.title | xml_escape }}</title>
-            <description>{{ post.content | codecogs | xml_escape }}</description>
-            <pubDate>{{ post.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
-            <link>{{ site.url }}{{ post.url }}</link>
-            <guid isPermaLink="true">{{ site.url }}{{ post.url }}</guid>
+            <title>{{- post.title | xml_escape -}}</title>
+            <description>{{- post.content | codecogs | xml_escape -}}</description>
+            <pubDate>{{- post.date | date: "%a, %d %b %Y %H:%M:%S %z" -}}</pubDate>
+            <link>{{- site.url -}}{{- post.url -}}</link>
+            <guid isPermaLink="true">{{- site.url -}}{{- post.url -}}</guid>
         </item>
-        {% endfor %}
+        {%- endfor -%}
     </channel>
 </rss>

--- a/blog/index.html
+++ b/blog/index.html
@@ -8,49 +8,49 @@ paginate:
 <div class="pure-g">
   <div class="pure-u-1 pure-u-md-2-3 pure-u-lg-2-3">
 
-    {% for post in paginator.posts %}
+    {%- for post in paginator.posts -%}
 
-    {% assign content = post.content %}
-    {% if content contains '<!--more-->' %}
-    {% assign content = content | split:'<!--more-->' | first %}
-    {% assign content = content | append: '<p><a href="' | append: site.baseurl | append: post.url | append: '">Seguir leyendo...</a></p>'%}
-    {% endif %}
+    {%- assign content = post.content -%}
+    {%- if content contains '<!--more-->' -%}
+    {%- assign content = content | split:'<!--more-->' | first -%}
+    {%- assign content = content | append: '<p><a href="' | append: site.baseurl | append: post.url | append: '">Seguir leyendo...</a></p>'-%}
+    {%- endif -%}
 
     <article class="post">
       
       <div class="category">
-        {% if post.category %}
-        {{ post.category }}
-        {% else %}
+        {%- if post.category -%}
+        {{- post.category -}}
+        {%- else -%}
         Sin categorizar
-        {% endif %}
+        {%- endif -%}
       </div>
       
       <h1>
-        <a href="{{ site.baseurl }}{{ post.url }}">
-          {{ post.title }}
+        <a href="{{- site.baseurl -}}{{- post.url -}}">
+          {{- post.title -}}
         </a>
       </h1>
       
       <span class="post-data">
-        {% for author in post.authors %}
-        {% if forloop.first %} {% elsif forloop.last %} y {% else %}, {% endif %}
-        <span class="author">{{ author }}</span>
-        {% endfor %}
+        {%- for author in post.authors -%}
+        {%- if forloop.first -%} {%- elsif forloop.last -%} y {%- else -%}, {%- endif -%}
+        <span class="author">{{- author -}}</span>
+        {%- endfor -%}
 
-        {% if post.license %}
+        {%- if post.license -%}
         <span class="license">
-          {{ post.license }}
+          {{- post.license -}}
         </span>
-        {% endif %}
+        {%- endif -%}
         
-        <a class="date" href='{{ site.baseurl }}{{ post.url }}'><time datetime='{{ post.date | date: "%Y-%m-%d" }}'>{{ post.date | date: "%d/%m/%Y" }}</time></a>
+        <a class="date" href='{{- site.baseurl -}}{{- post.url -}}'><time datetime='{{- post.date | date: "%Y-%m-%d" -}}'>{{- post.date | date: "%d/%m/%Y" -}}</time></a>
       </span>
-      {{ content }}
+      {{- content -}}
     </article>
-    {% endfor %}
+    {%- endfor -%}
 
-    {% include pagination.html archive=true site="blog" %}
+    {%- include pagination.html archive=true site="blog" -%}
 
   </div>
   <div class="pure-u-1 pure-u-md-1-24 pure-u-lg-1-24"></div>

--- a/contributing.html
+++ b/contributing.html
@@ -19,28 +19,28 @@ bodyclass:
   </div>
 </div>
 
-{% include banner
+{%- include banner
 side="left"
 title="Proyectos"
 description="Para colaborar directamente en nuestros proyectos, consulta [cómo escribir artículos para el blog](https://github.com/libreim/blog/blob/sites/CONTRIBUTING.md) y [cómo aportar recursos](/recursos)"
 classes="odd"
-%}
+-%}
 
 
-{% include banner
+{%- include banner
 side="right"
 title="Eventos"
 description="Si quieres estar al tanto de nuestros próximos eventos y proyectos, [inscríbete en nuestro formulario](http://goo.gl/forms/k4Yl1TK5XT2ZaDro1) para que te añadamos a la lista de correo y a nuestra organización de GitHub"
 classes="even"
-%}
+-%}
 
 
-{% include banner
+{%- include banner
 side="left"
 title="Contacto"
 description="Forma parte de la comunidad siguiendo nuestro [perfil en Twitter](https://twitter.com/libreim_), [canal de Telegram](https://telegram.me/libreim) y uniéndote a nuestro [grupo de Telegram](https://telegram.me/libreimseminarios)"
 classes="odd"
-%}
+-%}
 
 <div class="splash">
   <div class="pure-g">
@@ -57,42 +57,42 @@ classes="odd"
 
 
 
-{% include banner
+{%- include banner
 side="left"
 title="AMAT UGR"
 description="Asociación de estudiantes de matemáticas de la Universidad de Granada, con el objetivo de hacer llegar a grandes y pequeños el maravilloso mundo de las matemáticas"
 link="http://www.ugr.es/~amat/"
 classes="amat"
-%}
+-%}
 
-{% include banner
+{%- include banner
 side="right"
 title="Geek & Tech Girls"
 description="Comunidad que a través del Software Libre acerca la tecnología a mujeres de todas las edades, a la vez que lucha por una sociedad igualitaria e inclusiva"
 link="https://geekandtechgirls.github.io/"
 classes="gtg"
-%}
+-%}
 
-{% include banner
+{%- include banner
 side="left"
 title="Interferencias"
 description="Grupo ciberactivista sin ánimo de lucro que pretende reunir a una serie de personas interesadas en privacidad, vigilancia masiva, derechos en internet, seguridad y derivados"
 link="https://interferencias.github.io/"
 classes="intf"
-%}
+-%}
 
-{% include banner
+{%- include banner
 side="right"
 title="Python Granada"
 description="La comunidad dedicada a Python en Granada y alrededores"
 link="https://www.python-granada.es/"
 classes="pyg"
-%}
+-%}
 
-{% include banner
+{%- include banner
 side="left"
 title="OSL-UGR"
 description="Entidad perteneciente a la Delegación de la Rectora para la Universidad Digital que coordina actividades relacionadas con el software, hardware y cultura libre en la Universidad de Granada"
 link="http://osl.ugr.es"
 classes="osl"
-%}
+-%}

--- a/guia-de-estilo.md
+++ b/guia-de-estilo.md
@@ -222,7 +222,7 @@ una figura en el post con la siguiente sintaxis:
 
 ~~~markdown
 {: .fig}
-{% raw %}![]({{ site.baseurl }}/images/camino_a_la_imagen.png)  {% endraw %}
+{%- raw -%}![]({{- site.baseurl -}}/images/camino_a_la_imagen.png)  {%- endraw -%}
 **Figura 1.** Pie de la figura
 ~~~
 

--- a/guia-de-estilo.md
+++ b/guia-de-estilo.md
@@ -222,7 +222,7 @@ una figura en el post con la siguiente sintaxis:
 
 ~~~markdown
 {: .fig}
-{%- raw -%}![]({{- site.baseurl -}}/images/camino_a_la_imagen.png)  {%- endraw -%}
+{% raw %}![]({{- site.baseurl -}}/images/camino_a_la_imagen.png)  {% endraw %}
 **Figura 1.** Pie de la figura
 ~~~
 

--- a/nota-foro.md
+++ b/nota-foro.md
@@ -5,4 +5,4 @@ permalink: /overflow/
 redirect_from: /foro/
 ---
 
-[&larr; Volver a LibreIM]({{ site.baseurl }}/)
+[&larr; Volver a LibreIM]({{- site.baseurl -}}/)

--- a/recursos/new.html
+++ b/recursos/new.html
@@ -44,23 +44,23 @@ breadcrumbs: true
     </p>
     
     <figure class="fig">
-      <img src="{{ site.baseurl }}/assets/images/new-resource-1-fork.jpeg" />
+      <img src="{{- site.baseurl -}}/assets/images/new-resource-1-fork.jpeg" />
       Primero, confirma que quieres hacer un fork del repositorio.
     </figure>
 
     <figure class="fig">
 
-      <img src="{{ site.baseurl }}/assets/images/new-resource-2-propose.jpeg" />
+      <img src="{{- site.baseurl -}}/assets/images/new-resource-2-propose.jpeg" />
       Después, propón el nuevo archivo (los datos estarán rellenos, no tienes que hacer nada más).
     </figure>
 
     <figure class="fig">
-      <img src="{{ site.baseurl }}/assets/images/new-resource-3-compare.jpeg" />
-      <img src="{{ site.baseurl }}/assets/images/new-resource-4-create.jpeg" />
+      <img src="{{- site.baseurl -}}/assets/images/new-resource-3-compare.jpeg" />
+      <img src="{{- site.baseurl -}}/assets/images/new-resource-4-create.jpeg" />
       Finalmente, crea la <em>pull request</em>.
     </figure>
 </p>
 </details>
 </form>
 
-<script type="text/javascript" src="{{ site.baseurl }}/assets/js/new.js"></script>
+<script type="text/javascript" src="{{- site.baseurl -}}/assets/js/new.js"></script>


### PR DESCRIPTION
El html estaba lleno de whitespace que hacia que archivos de 100 lineas ocuparan mas de 700, en Liquid 4.0 se introducen `{%-` y `{{-` como alternativa a `{%` y `{{` que eliminaran ese whitespace.