### PR TITLE
Añade seminarios recientes

### DIFF
--- a/recursos/_posts/2018-06-21-cuadragesimo-octavo-seminario.md
+++ b/recursos/_posts/2018-06-21-cuadragesimo-octavo-seminario.md
@@ -1,0 +1,13 @@
+---
+title: Cuadragésimo octavo seminario
+
+authors: ['David Moya', 'Andrés Herrera', 'Mario Román', 'Braulio Valdivielso']
+tags: [seminarios]
+---
+
+
+* Superficies de Riemann y algunos teoremas globales de superficies en $\mathbb{R}^3$ -- David Moya
+* Polinomios ciclotómicos y semigrupos numéricos -- Andrés Herrera
+* Teoría de categorías y cálculo lambda -- Mario Román
+* Teoría de categorías aplicada al diseño de software -- Braulio Valdivielso
+

--- a/recursos/_posts/2018-09-21-cuadragesimo-noveno-seminario.md
+++ b/recursos/_posts/2018-09-21-cuadragesimo-noveno-seminario.md
@@ -1,0 +1,10 @@
+---
+title: Cuadragésimo noveno seminario
+
+authors: ['Mario Román']
+tags: [seminarios]
+---
+
+
+* [Constructivismo y computación](https://github.com/mroman42/libreim-constructiva) -- Mario Román
+

--- a/recursos/_posts/2018-09-22-quincuagesimo-seminario.md
+++ b/recursos/_posts/2018-09-22-quincuagesimo-seminario.md
@@ -1,0 +1,11 @@
+---
+title: Quincuagésimo seminario
+
+authors: ['David Charte']
+tags: [seminarios]
+---
+
+
+* 4 años de seminarios -- David Charte
+* Mi teorema favorito -- Colectivo
+

--- a/recursos/_posts/2018-09-29-quincuagesimo-primero-seminario.md
+++ b/recursos/_posts/2018-09-29-quincuagesimo-primero-seminario.md
@@ -1,0 +1,10 @@
+---
+title: Quincuagésimo primero seminario
+
+authors: ['Daniel Pozo']
+tags: [seminarios]
+---
+
+
+* Algunos resultados de probabilidad e inferencia estadística -- Daniel Pozo
+

--- a/recursos/_posts/2018-10-06-quincuagesimo-segundo-seminario.md
+++ b/recursos/_posts/2018-10-06-quincuagesimo-segundo-seminario.md
@@ -1,0 +1,11 @@
+---
+title: Quincuagésimo segundo seminario
+
+authors: ['David Charte', 'Pablo Baeyens']
+tags: [seminarios]
+---
+
+
+* Linux, Git y uso de la terminal -- David Charte
+* [Introducción a LaTeX](https://mx-psi.github.io/latex/) -- Pablo Baeyens
+

--- a/recursos/_posts/2018-10-20-quincuagesimo-tercer-seminario.md
+++ b/recursos/_posts/2018-10-20-quincuagesimo-tercer-seminario.md
@@ -1,0 +1,11 @@
+---
+title: Quincuagésimo tercer seminario
+
+authors: ['Bartolomé Ortiz', 'Yábir García']
+tags: [seminarios]
+---
+
+
+* Introducción y ejemplos de modelado matemático de sistemas biológicos -- Bartolomé Ortiz
+* Cómo construir un Instagram federado desde cero -- Yábir García
+

--- a/recursos/_posts/2018-12-01-quincuagesimo-cuarto-seminario.md
+++ b/recursos/_posts/2018-12-01-quincuagesimo-cuarto-seminario.md
@@ -1,0 +1,10 @@
+---
+title: Quincuagésimo cuarto seminario
+
+authors: ['Marta Fernández','Violeta Atienza']
+tags: [seminarios]
+---
+
+
+* Música y matemáticas -- Marta Fernández y Violeta Atienza
+

--- a/recursos/_posts/2018-12-15-quincuagesimo-quinto-seminario.md
+++ b/recursos/_posts/2018-12-15-quincuagesimo-quinto-seminario.md
@@ -1,0 +1,10 @@
+---
+title: Quincuagésimo quinto seminario
+
+authors: ['Víctor Buendía']
+tags: [seminarios]
+---
+
+
+* Física en videojuegos: diseño e implementación -- Víctor Buendía
+

--- a/recursos/_posts/2018-2-23-cuadragesimo-cuarto-seminario.md
+++ b/recursos/_posts/2018-2-23-cuadragesimo-cuarto-seminario.md
@@ -4,4 +4,4 @@ authors: ["José Antonio Álvarez"]
 tags: [seminarios]
 ---
 
-* Árboles y grafos: conceptos básicos - José Antonio Álvarez
+* [Árboles y grafos: conceptos básicos](https://github.com/Ocete/SeminarioGrafos) - José Antonio Álvarez

--- a/recursos/_posts/2018-3-3-cuadragesimo-quinto-seminario.md
+++ b/recursos/_posts/2018-3-3-cuadragesimo-quinto-seminario.md
@@ -4,5 +4,5 @@ authors: ["David Charte","Pablo Baeyens"]
 tags: [seminarios]
 ---
 
-* Generalizando la desigualdad de las medias - Pablo Baeyens
+* [Generalizando la desigualdad de las medias](/blog/2018/03/01/medias/) - Pablo Baeyens
 * Ruby en 10 líneas. Introducción a Enumerators - David Charte

--- a/recursos/_posts/2019-02-23-quincuagesimo-sexto-seminario.md
+++ b/recursos/_posts/2019-02-23-quincuagesimo-sexto-seminario.md
@@ -1,0 +1,10 @@
+---
+title: Quincuagésimo sexto seminario
+
+authors: ['José Antonio Álvarez']
+tags: [seminarios]
+---
+
+
+* [Cómo ser becario en una Big Tech: *The Coding Interview*](https://github.com/libreim/coding-interview-talk) -- José Antonio Álvarez
+

--- a/recursos/_posts/2019-03-16-quincuagesimo-septimo-seminario.md
+++ b/recursos/_posts/2019-03-16-quincuagesimo-septimo-seminario.md
@@ -1,0 +1,11 @@
+---
+title: Quincuagésimo séptimo seminario
+
+authors: ['Pablo Baeyens', 'Rodrigo Raya']
+tags: [seminarios]
+---
+
+
+* [Introducción a Haskell](https://github.com/libreim/haskell/releases/tag/v0.1) -- Pablo Baeyens
+* Introducción a Isabelle -- Rodrigo Raya
+

--- a/recursos/_posts/2019-03-30-quincuagesimo-octavo-seminario.md
+++ b/recursos/_posts/2019-03-30-quincuagesimo-octavo-seminario.md
@@ -1,0 +1,11 @@
+---
+title: Quincuagésimo octavo seminario
+
+authors: ['Pablo Baeyens', 'David Charte']
+tags: [seminarios]
+---
+
+
+* [Funtores, mónadas y otras clases de tipos en Haskell](https://github.com/libreim/haskell/releases/tag/v0.1-classes) -- Pablo Baeyens
+* Tutorial de Deep Learning con Keras y Tensorflow -- David Charte
+

--- a/recursos/_posts/2019-03-30-quincuagesimo-octavo-seminario.md
+++ b/recursos/_posts/2019-03-30-quincuagesimo-octavo-seminario.md
@@ -7,5 +7,5 @@ tags: [seminarios]
 
 
 * [Funtores, mónadas y otras clases de tipos en Haskell](https://github.com/libreim/haskell/releases/tag/v0.1-classes) -- Pablo Baeyens
-* [Tutorial de Deep Learning con Keras y Tensorflow](https://github.com/fdavidcl/dl-tutorial) -- David Charte
+* [Tutorial de Deep Learning con Keras y Tensorflow](https://github.com/libreim/dl-tutorial) -- David Charte
 

--- a/recursos/_posts/2019-03-30-quincuagesimo-octavo-seminario.md
+++ b/recursos/_posts/2019-03-30-quincuagesimo-octavo-seminario.md
@@ -7,5 +7,5 @@ tags: [seminarios]
 
 
 * [Funtores, mónadas y otras clases de tipos en Haskell](https://github.com/libreim/haskell/releases/tag/v0.1-classes) -- Pablo Baeyens
-* Tutorial de Deep Learning con Keras y Tensorflow -- David Charte
+* [Tutorial de Deep Learning con Keras y Tensorflow](https://github.com/fdavidcl/dl-tutorial) -- David Charte
 

--- a/recursos/_posts/2019-04-26-quincuagesimo-noveno-seminario.md
+++ b/recursos/_posts/2019-04-26-quincuagesimo-noveno-seminario.md
@@ -1,0 +1,10 @@
+---
+title: Quincuagésimo noveno seminario
+
+authors: ['Mario Román']
+tags: [seminarios]
+---
+
+
+* Monoides coloreados -- Mario Román
+

--- a/recursos/_posts/2019-04-27-sexagesimo-seminario.md
+++ b/recursos/_posts/2019-04-27-sexagesimo-seminario.md
@@ -1,0 +1,10 @@
+---
+title: Sexagésimo seminario
+
+authors: ['Pablo Baeyens']
+tags: [seminarios]
+---
+
+
+* [Programando ordenadores cuánticos](https://mx-psi.github.io/libreim-quantum) -- Pablo Baeyens
+

--- a/recursos/_posts/2019-05-18-sexagesimo-primer-seminario.md
+++ b/recursos/_posts/2019-05-18-sexagesimo-primer-seminario.md
@@ -1,0 +1,10 @@
+---
+title: Sexagésimo primer seminario
+
+authors: ['José Alberto Orejuela']
+tags: [seminarios]
+---
+
+
+* [El algoritmo de Shor paso a paso](https://git.sr.ht/~josealberto4444/algoritmo-de-shor) -- José Alberto Orejuela
+

--- a/recursos/_posts/2019-10-02-sexagesimo-segundo-seminario.md
+++ b/recursos/_posts/2019-10-02-sexagesimo-segundo-seminario.md
@@ -1,0 +1,10 @@
+---
+title: Sexagésimo segundo seminario
+
+authors: ['Mario Román']
+tags: [seminarios]
+---
+
+
+* [Adjunciones](https://github.com/mroman42/adjunctions) -- Mario Román
+

--- a/recursos/_posts/2019-10-19-sexagesimo-tercer-seminario.md
+++ b/recursos/_posts/2019-10-19-sexagesimo-tercer-seminario.md
@@ -1,0 +1,13 @@
+---
+title: Sexagésimo tercer seminario
+
+authors: ['David Charte', 'José María Martín', 'Daniel Pozo', 'Pablo Baeyens']
+tags: [seminarios]
+---
+
+
+* Linux, Git y software libre -- David Charte
+* Introducción a LaTeX -- José María Martín
+* apuntesDGIIM -- Daniel Pozo
+* [Técnicas de estudio](https://mx-psi.github.io/studying/) -- Pablo Baeyens
+

--- a/recursos/_posts/2019-10-19-sexagesimo-tercer-seminario.md
+++ b/recursos/_posts/2019-10-19-sexagesimo-tercer-seminario.md
@@ -6,7 +6,7 @@ tags: [seminarios]
 ---
 
 
-* Linux, Git y software libre -- David Charte
+* [Linux, Git y software libre](https://github.com/libreim/herramientas-im/releases/tag/2019) -- David Charte
 * Introducción a LaTeX -- José María Martín
 * apuntesDGIIM -- Daniel Pozo
 * [Técnicas de estudio](https://mx-psi.github.io/studying/) -- Pablo Baeyens


### PR DESCRIPTION
Este PR añade los seminarios que faltaban hasta la fecha en recursos. He añadido algunos enlaces de los contenidos de las charlas pero me faltan algunos que me suena que están públicos pero no encuentro. 

En concreto me gustaría añadir el de @fdavidcl de Keras y el último de @jmml97 de LaTeX.